### PR TITLE
issue with Jinja-safe way to access an attribute that might not exist form a python object 

### DIFF
--- a/app/templates_nl/views/manage-users.html
+++ b/app/templates_nl/views/manage-users.html
@@ -37,9 +37,11 @@
                 </span>&ensp;
               {%- endif -%}
               <span class="hint">
-              {%- if user.is_invited_user and user.status == 'pending' -%}
+              {# Jinja-safe way to access an attribute form a python object that might not exist. #}
+              {# (Xobject.Xattribute | default(None)) == 'value' #}
+              {%- if user.is_invited_user and (user.status | default(None)) == 'pending' -%}
                 <span class="live-search-relevant">{{ user.email_address }}</span> (uitgenodigd)
-              {%- elif user.is_invited_user and user.status == 'cancelled' -%}
+              {%- elif user.is_invited_user and (user.status | default(None)) == 'canceled' -%}
                 <span class="live-search-relevant">{{ user.email_address }}</span> (uitnodiging geannuleerd)
               {%- elif user.id == current_user.id -%}
                 <span class="live-search-relevant">(jij)</span>
@@ -79,7 +81,7 @@
             </div>
             <div class="govuk-grid-column-one-quarter">
               {% if current_user.has_permissions('manage_service') %}
-                {% if user.is_invited_user and user.status == 'pending' %}
+                {% if user.is_invited_user and (user.status | default(None)) == 'pending' %}
                   <a class="user-list-edit-link govuk-link govuk-link--no-visited-state" href="{{ url_for('main.cancel_invited_user', service_id=current_service.id, invited_user_id=user.id)}}">Uitnodiging annuleren<span class="govuk-visually-hidden"> voor {{ user.email_address }}</span></a>
                 {% elif user.is_editable_by(current_user) %}
                   <a class="user-list-edit-link govuk-link govuk-link--no-visited-state" href="{{ url_for('main.edit_user_permissions', service_id=current_service.id, user_id=user.id)}}">Gegevens wijzigen<span class="govuk-visually-hidden"> voor {{ user.name }} {{ user.email_address }}</span></a>

--- a/app/templates_nl/views/organisations/organisation/users/index.html
+++ b/app/templates_nl/views/organisations/organisation/users/index.html
@@ -28,9 +28,11 @@
                 <span class="heading-small">{{ user.name }}</span>&ensp;
               {%- endif -%}
               <span class="hint">
-                {%- if user.is_invited_user and user.status == 'pending' -%}
+                {# Jinja-safe way to access an attribute form a python object that might not exist. #}
+                {# (Xobject.Xattribute | default(None)) == 'value' #}
+                {%- if user.is_invited_user and (user.status | default(None)) == 'pending' -%}
                   {{ user.email_address }} (uitgenodigd)
-                {%- elif user.is_invited_user and user.status == 'cancelled' -%}
+                {%- elif user.is_invited_user and (user.status | default(None)) == 'cancelled' -%}
                   {{ user.email_address }} (uitnodiging geannuleerd)
                 {%- elif user.id == current_user.id -%}
                   (u)
@@ -53,7 +55,7 @@
 
           </div>
           <div class="govuk-grid-column-one-quarter">
-            {% if user.status == 'pending' %}
+            {% if (user.status | default(None)) == 'pending' %}
               <a class="govuk-link govuk-link--no-visited-state user-list-edit-link" href="{{ url_for('main.cancel_invited_org_user', org_id=current_org.id, invited_user_id=user.id)}}">Uitnodiging annuleren<span class="govuk-visually-hidden"> voor {{ user.email_address }}</span></a>
             {% elif user.is_editable_by(current_user) %}
               <a class="user-list-edit-link govuk-link govuk-link--no-visited-state" href="{{ url_for('main.edit_organisation_user', org_id=current_org.id, user_id=user.id)}}">Gegevens wijzigen<span class="govuk-visually-hidden"> voor {{ user.name }} {{ user.email_address }}</span></a>


### PR DESCRIPTION
fixed issue with Jinja-safe way to access an attribute that might not exist form a python object 

fixes #24, closes #24 